### PR TITLE
Pin nokogiri to correct version for ruby version

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -2,3 +2,4 @@
 * Paul Thornthwaite <tokengeek@gmail.com>
 * Paulo Henrique Lopes Ribeiro <plribeiro3000@gmail.com>
 * Wesley Beary <geemus@gmail.com>
+* Tomer Brisker <tbrisker@gmail.com>

--- a/fog-xml.gemspec
+++ b/fog-xml.gemspec
@@ -23,7 +23,14 @@ Gem::Specification.new do |spec|
   spec.require_paths = %w(lib)
 
   spec.add_dependency "fog-core"
-  spec.add_dependency "nokogiri", "~> 1.5", ">= 1.5.11"
+  case RUBY_VERSION
+  when /^(1\.8.*|1\.9\.[01])$/
+    spec.add_dependency "nokogiri", ">= 1.5.11", "< 1.6.2"
+  when /^(1\.9\.([^01]|\d.+)|2\.0.*)$/
+    spec.add_dependency "nokogiri", ">= 1.5.11", "< 1.7.0"
+  else
+    spec.add_dependency "nokogiri", ">= 1.5.11", "< 2.0.0"
+  end
   spec.add_development_dependency "rake"
   spec.add_development_dependency "minitest"
   spec.add_development_dependency "turn"

--- a/fog-xml.gemspec
+++ b/fog-xml.gemspec
@@ -25,13 +25,15 @@ Gem::Specification.new do |spec|
   spec.add_dependency "fog-core"
   case RUBY_VERSION
   when /^(1\.8.*|1\.9\.[01])$/
+    spec.add_development_dependency "rake", "< 11.0.0"
     spec.add_dependency "nokogiri", ">= 1.5.11", "< 1.6.2"
   when /^(1\.9\.([^01]|\d.+)|2\.0.*)$/
+    spec.add_development_dependency "rake"
     spec.add_dependency "nokogiri", ">= 1.5.11", "< 1.7.0"
   else
+    spec.add_development_dependency "rake"
     spec.add_dependency "nokogiri", ">= 1.5.11", "< 2.0.0"
   end
-  spec.add_development_dependency "rake"
   spec.add_development_dependency "minitest"
   spec.add_development_dependency "turn"
   spec.add_development_dependency "pry"

--- a/fog-xml.gemspec
+++ b/fog-xml.gemspec
@@ -24,19 +24,20 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency "fog-core"
   case RUBY_VERSION
-  when /^(1\.8.*|1\.9\.[01])$/
-    spec.add_development_dependency "rake", "< 11.0.0"
+  when /^(1\.8.*|1\.9\.[012])$/
     spec.add_dependency "nokogiri", ">= 1.5.11", "< 1.6.2"
-  when /^(1\.9\.([^01]|\d.+)|2\.0.*)$/
-    spec.add_development_dependency "rake"
+    spec.add_development_dependency "rake", "< 11.0.0"
+  when /^(1\.9\.([^012]|\d.+)|2\.0.*)$/
     spec.add_dependency "nokogiri", ">= 1.5.11", "< 1.7.0"
-  else
     spec.add_development_dependency "rake"
+  else
     spec.add_dependency "nokogiri", ">= 1.5.11", "< 2.0.0"
+    spec.add_development_dependency "rake"
   end
   spec.add_development_dependency "minitest"
   spec.add_development_dependency "turn"
   spec.add_development_dependency "pry"
   spec.add_development_dependency "coveralls" if RUBY_VERSION.to_f >= 1.9
+  spec.add_development_dependency "term-ansicolor", "< 1.4.0" if RUBY_VERSION.start_with? "1.9."
   spec.add_development_dependency "tins", "< 1.7.0" if RUBY_VERSION.start_with? "1.9."
 end

--- a/fog-xml.gemspec
+++ b/fog-xml.gemspec
@@ -38,4 +38,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "turn"
   spec.add_development_dependency "pry"
   spec.add_development_dependency "coveralls" if RUBY_VERSION.to_f >= 1.9
+  spec.add_development_dependency "tins", "< 1.7.0" if RUBY_VERSION.start_with? "1.9."
 end


### PR DESCRIPTION
Nokogiri 1.7 dropped support for Ruby < 2.1, causing any gem dependent on this to fail building for those versions. While I'm at it, also locked nokogiri version for Ruby < 1.9.3, which was dropped in nokogiri 1.6.2.