### PR TITLE
update nokogiri dependency

### DIFF
--- a/fog-xml.gemspec
+++ b/fog-xml.gemspec
@@ -25,7 +25,7 @@ Gem::Specification.new do |spec|
   spec.required_ruby_version = '>= 2.0.0'
 
   spec.add_dependency "fog-core"
-  spec.add_dependency "nokogiri", ">= 1.5.11", "< 1.7.0" #pinned for 2.0 support
+  spec.add_dependency "nokogiri", ">= 1.5.11", "< 2.0.0" #pinned for 2.0 support
   spec.add_development_dependency "rake"
   spec.add_development_dependency "minitest"
   spec.add_development_dependency "turn"


### PR DESCRIPTION
The nokogiri dependency used to allow up to 2.0.0 before a recent update. 1.7.0 has a deprecation fix for ruby 2.4 and needs to be allowed.